### PR TITLE
Vmk patch

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,13 @@
 
 > This is experimental software and hardware. It's not ready to use for professional or production use.
 
-The board (in /hardware/) is compatible with the "Debug Card" connector found on some Lenovo laptops. The firmware currently only supports LPC, not SPI TPMs.
+The board (in /hardware/) is compatible with the "Debug Card" connector found on some Lenovo laptops only for LPC. 
+
+The firmare supports LPC and SPI TPMs. Where for the later there are options to either sniff on the TPM
+directly or if Buslines are shared with BIOS (typically Winbond 25Qxxx) SPI can also be sniffed there.
+
+! The hardware is currently not compatible with the SPI / SPI-BIOS ! Currently you need to use either a 
+testclip, probe pins, solder to the pins or other means to connect to the  TPM / BIOS pins.
 
 ## Building
 
@@ -20,4 +26,15 @@ The board files are in `hardware/`, the Pogo pins used are of the type: P50-B1-1
 
 ## Usage
 
+### LPC
+
 Just connect to the serial port, boot your machine, and push against the card connector!
+
+### SPI / SPI-BIOS
+
+Connect DI, DO, CLK, SELECT and GND according to this 
+* GPIO 2 -----> DI
+* GPIO 3 -----> DO
+* GPIO 4 -----> CLK
+* GPIO 5 -----> SELECT
+* GND Pico ---> GND Bios/Tpm

--- a/Readme.md
+++ b/Readme.md
@@ -2,13 +2,7 @@
 
 > This is experimental software and hardware. It's not ready to use for professional or production use.
 
-The board (in /hardware/) is compatible with the "Debug Card" connector found on some Lenovo laptops only for LPC. 
-
-The firmare supports LPC and SPI TPMs. Where for the later there are options to either sniff on the TPM
-directly or if Buslines are shared with BIOS (typically Winbond 25Qxxx) SPI can also be sniffed there.
-
-! The hardware is currently not compatible with the SPI / SPI-BIOS ! Currently you need to use either a 
-testclip, probe pins, solder to the pins or other means to connect to the  TPM / BIOS pins.
+The board (in /hardware/) is compatible with the "Debug Card" connector found on some Lenovo laptops. The firmware currently only supports LPC, not SPI TPMs.
 
 ## Building
 
@@ -26,15 +20,5 @@ The board files are in `hardware/`, the Pogo pins used are of the type: P50-B1-1
 
 ## Usage
 
-### LPC
-
 Just connect to the serial port, boot your machine, and push against the card connector!
 
-### SPI / SPI-BIOS
-
-Connect DI, DO, CLK, SELECT and GND according to this 
-* GPIO 2 -----> DI
-* GPIO 3 -----> DO
-* GPIO 4 -----> CLK
-* GPIO 5 -----> SELECT
-* GND Pico ---> GND Bios/Tpm

--- a/main.c
+++ b/main.c
@@ -160,8 +160,13 @@ int main() {
         // Wait til the msg_buffer_ptr is full
         while((msg_buffer_ptr - popped) < 44) {
         }
-        
-        if(memcmp(message_buffer + popped, vmk_header, 5) == 0) {
+        // Generic VMK looks like
+        // 2C00|0X00|0X00|0000|0X20|0000
+        if( (memcmp(message_buffer + popped, vmk_header, 2) == 0) &&\
+            (memcmp(message_buffer + popped + 3, vmk_header + 3, 1) == 0) &&\
+            (memcmp(message_buffer + popped + 5, vmk_header + 5, 3) == 0) &&\
+            (memcmp(message_buffer + popped + 9, vmk_header + 9, 3) == 0))
+        {
             printf("[+] Bitlocker Volume Master Key found:\n");
 
             for(int i=0; i < 2; i++) {


### PR DESCRIPTION
this is a simple crude approach to make the search for the vmk header more generic. In the end it is only 3 bytes that might vary from the total of 12 bytes for the vmk header. so the comparison just skips the 3 bytes in question and compares the remaining 9 bytes only. I know it is not very elegant but it worked in my setup and should in general work fine.
